### PR TITLE
Add options for applications behind reverse proxys

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ recaptcha:
     failure-url: /login # URL to redirect to when user authentication fails.
     login-failures-threshold: 5 # Number of allowed login failures before reCAPTCHA must be displayed.
     continue-on-validation-http-error: true # Permits or denies continuing user authentication process after reCAPTCHA validation fails because of HTTP error.
+    proxy: false # Indicates whether the application is behind a proxy (thus a request's remote address will be the proxy's ip).
+    forwardHeader: X-Forwarded-For # The header from which to read the client's ip, used when proxy is set to true.
   testing:
     enabled: false # Flag for enabling and disabling testing mode.
     success-result: true # Defines successful or unsuccessful validation result, can be changed during tests.

--- a/src/main/java/com/github/mkopylec/recaptcha/RecaptchaProperties.java
+++ b/src/main/java/com/github/mkopylec/recaptcha/RecaptchaProperties.java
@@ -160,6 +160,16 @@ public class RecaptchaProperties {
          */
         private boolean continueOnValidationHttpError = true;
 
+        /**
+         * Indicates whether the application is behind a proxy
+         * (thus a request's remote address will be the proxy's ip).
+         */
+        private boolean proxy=false;
+        /**
+         * The header from which to read the client's ip, used when proxy is set to true.
+         */
+        private String forwardHeader = "X-Forwarded-For";
+
         public String getFailureUrl() {
             return failureUrl;
         }
@@ -182,6 +192,22 @@ public class RecaptchaProperties {
 
         public void setContinueOnValidationHttpError(boolean continueOnValidationHttpError) {
             this.continueOnValidationHttpError = continueOnValidationHttpError;
+        }
+
+        public String getForwardHeader() {
+            return forwardHeader;
+        }
+
+        public void setForwardHeader(String forwardHeader) {
+            this.forwardHeader = forwardHeader;
+        }
+
+        public boolean isProxy() {
+            return proxy;
+        }
+
+        public void setProxy(boolean proxy) {
+            this.proxy = proxy;
         }
     }
 

--- a/src/main/java/com/github/mkopylec/recaptcha/security/RecaptchaAuthenticationFilter.java
+++ b/src/main/java/com/github/mkopylec/recaptcha/security/RecaptchaAuthenticationFilter.java
@@ -49,7 +49,7 @@ public class RecaptchaAuthenticationFilter extends UsernamePasswordAuthenticatio
         if (failuresManager.isRecaptchaRequired(request)) {
             try {
                 String recaptchaResponse = obtainRecaptchaResponse(request);
-                ValidationResult result = recaptchaValidator.validate(recaptchaResponse, request.getRemoteAddr());
+                ValidationResult result = recaptchaValidator.validate(recaptchaResponse, this.getRemoteAddr(request));
                 if (result.isFailure()) {
                     throw new RecaptchaAuthenticationException(result.getErrorCodes());
                 }
@@ -64,7 +64,21 @@ public class RecaptchaAuthenticationFilter extends UsernamePasswordAuthenticatio
         return super.attemptAuthentication(request, response);
     }
 
-    @Override
+
+  /**
+   * Determine a requests original ip (either from the remoteAddress directly, or in a proxy setting from the specified header).
+   *
+   * @param request The request from which to determine the client's ip.
+   * @return the remote address
+   */
+    public String getRemoteAddr(HttpServletRequest request) {
+        return this.recaptcha.getSecurity().isProxy() ?
+            request.getHeader(this.recaptcha.getSecurity().getForwardHeader()) :
+            request.getRemoteAddr();
+    }
+
+
+  @Override
     public void setAuthenticationSuccessHandler(AuthenticationSuccessHandler successHandler) {
         if (!LoginFailuresClearingHandler.class.isAssignableFrom(successHandler.getClass())) {
             throw new IllegalArgumentException("Invalid login success handler. Handler must be an instance of " + LoginFailuresClearingHandler.class.getName() + " but is " + successHandler);


### PR DESCRIPTION
This pull request solves  #11 
Reverse proxys "override" the client's IP address, which is needed for validating Recaptcha Responses. Proxys usually add a header X-Forwarded-For holding the client's IP address.

Added are two options to security:
* proxy specifies whether the application is running behind a proxy
* forwardHeader allows specifying a different header (standard is X-Forwarded-For) for the client's IP