### PR TITLE
Updated to use more appropriate ConcurrentHashMap methods.

### DIFF
--- a/src/main/java/com/github/mkopylec/recaptcha/security/login/InMemoryLoginFailuresManager.java
+++ b/src/main/java/com/github/mkopylec/recaptcha/security/login/InMemoryLoginFailuresManager.java
@@ -23,13 +23,13 @@ public class InMemoryLoginFailuresManager extends LoginFailuresManager {
     public void addLoginFailure(HttpServletRequest request) {
         String username = getUsername(request);
         log.debug("Adding login failure for username: {}", username);
-        loginFailures.put(username, getLoginFailuresCount(request) + 1);
+        loginFailures.compute(username, (key, value) -> value == null ? 1 : value + 1);
     }
 
     @Override
     public int getLoginFailuresCount(HttpServletRequest request) {
         String username = getUsername(request);
-        int count = loginFailures.get(username) == null ? 0 : loginFailures.get(username);
+        int count = loginFailures.getOrDefault(username, 0);
         log.debug("Getting login failures count: {} for username: {}", count, username);
         return count;
     }


### PR DESCRIPTION
This resolves the concurrency issues present with the InMemoryLoginFailureManager raised in https://github.com/mkopylec/recaptcha-spring-boot-starter/issues/14